### PR TITLE
Export UUID type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zingage/postgres-multi-tenant-ids",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PostgreSQL IDs for secure multi-tenant applications",
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export type {
   TenantShortId,
   UnscopedId,
 } from "./helpers/config-agnostic-types.js";
-export type { UUIDV4, UUIDV8 } from "./helpers/utils.js";
+export type { UUID, UUIDV4, UUIDV8 } from "./helpers/utils.js";
 
 export function initialize<
   const TenantScopedEntityTypeConfigs extends NamedEntityTypeConfigs,


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR
Exported the `UUID` type for broader use.

## Why we made these changes
To allow external modules and applications to import and utilize the `UUID` type, enhancing type safety and reusability across the codebase.

## What changed?
- `package.json`: Version updated from 1.0.1 to 1.0.2.
- `src/index.ts`: The `UUID` type is now exported from `./helpers/utils.js`.

## Validation
- [ ] Confirmed `UUID` type is importable in consuming projects.
- [ ] Verified type usage in external modules compiles without errors.
<!-- mesa-description-end -->